### PR TITLE
Se añade el crud para carreras

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -19,6 +19,12 @@ model usuario {
   rol_usu rol_usuario
   fec_cre_usu DateTime @default(now())
 }
+model Carrera {
+  id        String   @id @default(uuid())
+  nombre    String   @unique
+  estado    Boolean  @default(true)
+  creadaEn  DateTime @default(now())
+}
 
 enum rol_usuario {
   ADMIN

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -2,6 +2,8 @@ const express = require("express");
 const cors = require("cors");
 const dotenv = require("dotenv");
 
+import carreraRoutes from './routes/carrera.routes.js';
+
 dotenv.config();
 
 const app = express(); // ← también te faltaba crear la instancia de la app
@@ -12,6 +14,9 @@ app.use(express.json());
 app.get("/", (req, res) => {
   res.send("API AcademicEvents funcionando");
 });
+
+// Rutas
+app.use('/api', carreraRoutes);  // ← Aquí se registran
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => console.log(`Servidor en puerto ${PORT}`));

--- a/backend/src/controllers/carrera.controller.js
+++ b/backend/src/controllers/carrera.controller.js
@@ -1,0 +1,52 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+// Obtener todas las carreras
+export const obtenerCarreras = async (req, res) => {
+  try {
+    const carreras = await prisma.carrera.findMany();
+    res.json(carreras);
+  } catch (error) {
+    res.status(500).json({ mensaje: 'Error al obtener carreras' });
+  }
+};
+
+// Crear nueva carrera
+export const crearCarrera = async (req, res) => {
+  try {
+    const { nombre } = req.body;
+    const nueva = await prisma.carrera.create({
+      data: { nombre }
+    });
+    res.status(201).json(nueva);
+  } catch (error) {
+    res.status(400).json({ mensaje: 'No se pudo crear la carrera' });
+  }
+};
+
+// Actualizar carrera
+export const actualizarCarrera = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { nombre, estado } = req.body;
+    const actualizada = await prisma.carrera.update({
+      where: { id },
+      data: { nombre, estado }
+    });
+    res.json(actualizada);
+  } catch (error) {
+    res.status(404).json({ mensaje: 'Carrera no encontrada' });
+  }
+};
+
+// Eliminar carrera
+export const eliminarCarrera = async (req, res) => {
+  try {
+    const { id } = req.params;
+    await prisma.carrera.delete({ where: { id } });
+    res.json({ mensaje: 'Carrera eliminada' });
+  } catch (error) {
+    res.status(404).json({ mensaje: 'No se pudo eliminar la carrera' });
+  }
+};

--- a/backend/src/generated/prisma/edge.js
+++ b/backend/src/generated/prisma/edge.js
@@ -104,6 +104,13 @@ exports.Prisma.UsuarioScalarFieldEnum = {
   fec_cre_usu: 'fec_cre_usu'
 };
 
+exports.Prisma.CarreraScalarFieldEnum = {
+  id: 'id',
+  nombre: 'nombre',
+  estado: 'estado',
+  creadaEn: 'creadaEn'
+};
+
 exports.Prisma.SortOrder = {
   asc: 'asc',
   desc: 'desc'
@@ -119,7 +126,8 @@ exports.rol_usuario = exports.$Enums.rol_usuario = {
 };
 
 exports.Prisma.ModelName = {
-  usuario: 'usuario'
+  usuario: 'usuario',
+  Carrera: 'Carrera'
 };
 /**
  * Create the Client
@@ -132,7 +140,7 @@ const config = {
       "value": "prisma-client-js"
     },
     "output": {
-      "value": "C:\\Users\\gabri\\OneDrive\\Desktop\\AcademicEvents\\backend\\src\\generated\\prisma",
+      "value": "C:\\Users\\User\\Desktop\\academicEvents\\AcademicEvents\\backend\\src\\generated\\prisma",
       "fromEnvVar": null
     },
     "config": {
@@ -146,7 +154,7 @@ const config = {
       }
     ],
     "previewFeatures": [],
-    "sourceFilePath": "C:\\Users\\gabri\\OneDrive\\Desktop\\AcademicEvents\\backend\\prisma\\schema.prisma",
+    "sourceFilePath": "C:\\Users\\User\\Desktop\\academicEvents\\AcademicEvents\\backend\\prisma\\schema.prisma",
     "isCustomOutput": true
   },
   "relativeEnvPaths": {
@@ -160,22 +168,21 @@ const config = {
     "db"
   ],
   "activeProvider": "postgresql",
-  "postinstall": false,
   "inlineDatasources": {
     "db": {
       "url": {
         "fromEnvVar": "DATABASE_URL",
-        "value": null
+        "value": "postgresql://postgres:12345@localhost:5432/academicevents"
       }
     }
   },
-  "inlineSchema": "generator client {\n  provider = \"prisma-client-js\"\n  output   = \"../src/generated/prisma\"\n}\n\ndatasource db {\n  provider = \"postgresql\"\n  url      = env(\"DATABASE_URL\")\n}\n\nmodel usuario {\n  id_usu      String      @id @default(uuid())\n  ced_usu     String      @unique\n  nom_usu     String\n  ape_usu     String\n  cor_usu     String      @unique\n  con_usu     String\n  cel_usu     String      @db.Char(10) //Acepta solo 10 caracteres\n  rol_usu     rol_usuario\n  fec_cre_usu DateTime    @default(now())\n}\n\nenum rol_usuario {\n  ADMIN\n  ESTUDIANTE\n}\n",
-  "inlineSchemaHash": "81e9fd5271bbbeb9fc318243fe2494d50983d7beb52884a9b53ae3576347caf0",
+  "inlineSchema": "generator client {\n  provider = \"prisma-client-js\"\n  output   = \"../src/generated/prisma\"\n}\n\ndatasource db {\n  provider = \"postgresql\"\n  url      = env(\"DATABASE_URL\")\n}\n\nmodel usuario {\n  id_usu      String      @id @default(uuid())\n  ced_usu     String      @unique\n  nom_usu     String\n  ape_usu     String\n  cor_usu     String      @unique\n  con_usu     String\n  cel_usu     String      @db.Char(10) //Acepta solo 10 caracteres\n  rol_usu     rol_usuario\n  fec_cre_usu DateTime    @default(now())\n}\n\nmodel Carrera {\n  id       String   @id @default(uuid())\n  nombre   String   @unique\n  estado   Boolean  @default(true)\n  creadaEn DateTime @default(now())\n}\n\nenum rol_usuario {\n  ADMIN\n  ESTUDIANTE\n}\n",
+  "inlineSchemaHash": "b180025db88e7593dc7fc08d49be91b171315f5025a68f831e26d6c76788b1f9",
   "copyEngine": true
 }
 config.dirname = '/'
 
-config.runtimeDataModel = JSON.parse("{\"models\":{\"usuario\":{\"dbName\":null,\"schema\":null,\"fields\":[{\"name\":\"id_usu\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":false,\"isId\":true,\"isReadOnly\":false,\"hasDefaultValue\":true,\"type\":\"String\",\"nativeType\":null,\"default\":{\"name\":\"uuid\",\"args\":[4]},\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"ced_usu\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":true,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":false,\"type\":\"String\",\"nativeType\":null,\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"nom_usu\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":false,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":false,\"type\":\"String\",\"nativeType\":null,\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"ape_usu\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":false,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":false,\"type\":\"String\",\"nativeType\":null,\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"cor_usu\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":true,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":false,\"type\":\"String\",\"nativeType\":null,\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"con_usu\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":false,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":false,\"type\":\"String\",\"nativeType\":null,\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"cel_usu\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":false,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":false,\"type\":\"String\",\"nativeType\":[\"Char\",[\"10\"]],\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"rol_usu\",\"kind\":\"enum\",\"isList\":false,\"isRequired\":true,\"isUnique\":false,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":false,\"type\":\"rol_usuario\",\"nativeType\":null,\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"fec_cre_usu\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":false,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":true,\"type\":\"DateTime\",\"nativeType\":null,\"default\":{\"name\":\"now\",\"args\":[]},\"isGenerated\":false,\"isUpdatedAt\":false}],\"primaryKey\":null,\"uniqueFields\":[],\"uniqueIndexes\":[],\"isGenerated\":false}},\"enums\":{\"rol_usuario\":{\"values\":[{\"name\":\"ADMIN\",\"dbName\":null},{\"name\":\"ESTUDIANTE\",\"dbName\":null}],\"dbName\":null}},\"types\":{}}")
+config.runtimeDataModel = JSON.parse("{\"models\":{\"usuario\":{\"dbName\":null,\"schema\":null,\"fields\":[{\"name\":\"id_usu\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":false,\"isId\":true,\"isReadOnly\":false,\"hasDefaultValue\":true,\"type\":\"String\",\"nativeType\":null,\"default\":{\"name\":\"uuid\",\"args\":[4]},\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"ced_usu\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":true,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":false,\"type\":\"String\",\"nativeType\":null,\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"nom_usu\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":false,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":false,\"type\":\"String\",\"nativeType\":null,\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"ape_usu\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":false,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":false,\"type\":\"String\",\"nativeType\":null,\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"cor_usu\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":true,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":false,\"type\":\"String\",\"nativeType\":null,\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"con_usu\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":false,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":false,\"type\":\"String\",\"nativeType\":null,\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"cel_usu\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":false,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":false,\"type\":\"String\",\"nativeType\":[\"Char\",[\"10\"]],\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"rol_usu\",\"kind\":\"enum\",\"isList\":false,\"isRequired\":true,\"isUnique\":false,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":false,\"type\":\"rol_usuario\",\"nativeType\":null,\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"fec_cre_usu\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":false,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":true,\"type\":\"DateTime\",\"nativeType\":null,\"default\":{\"name\":\"now\",\"args\":[]},\"isGenerated\":false,\"isUpdatedAt\":false}],\"primaryKey\":null,\"uniqueFields\":[],\"uniqueIndexes\":[],\"isGenerated\":false},\"Carrera\":{\"dbName\":null,\"schema\":null,\"fields\":[{\"name\":\"id\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":false,\"isId\":true,\"isReadOnly\":false,\"hasDefaultValue\":true,\"type\":\"String\",\"nativeType\":null,\"default\":{\"name\":\"uuid\",\"args\":[4]},\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"nombre\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":true,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":false,\"type\":\"String\",\"nativeType\":null,\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"estado\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":false,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":true,\"type\":\"Boolean\",\"nativeType\":null,\"default\":true,\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"creadaEn\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":false,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":true,\"type\":\"DateTime\",\"nativeType\":null,\"default\":{\"name\":\"now\",\"args\":[]},\"isGenerated\":false,\"isUpdatedAt\":false}],\"primaryKey\":null,\"uniqueFields\":[],\"uniqueIndexes\":[],\"isGenerated\":false}},\"enums\":{\"rol_usuario\":{\"values\":[{\"name\":\"ADMIN\",\"dbName\":null},{\"name\":\"ESTUDIANTE\",\"dbName\":null}],\"dbName\":null}},\"types\":{}}")
 defineDmmfProperty(exports.Prisma, config.runtimeDataModel)
 config.engineWasm = undefined
 config.compilerWasm = undefined

--- a/backend/src/generated/prisma/index-browser.js
+++ b/backend/src/generated/prisma/index-browser.js
@@ -132,6 +132,13 @@ exports.Prisma.UsuarioScalarFieldEnum = {
   fec_cre_usu: 'fec_cre_usu'
 };
 
+exports.Prisma.CarreraScalarFieldEnum = {
+  id: 'id',
+  nombre: 'nombre',
+  estado: 'estado',
+  creadaEn: 'creadaEn'
+};
+
 exports.Prisma.SortOrder = {
   asc: 'asc',
   desc: 'desc'
@@ -147,7 +154,8 @@ exports.rol_usuario = exports.$Enums.rol_usuario = {
 };
 
 exports.Prisma.ModelName = {
-  usuario: 'usuario'
+  usuario: 'usuario',
+  Carrera: 'Carrera'
 };
 
 /**

--- a/backend/src/generated/prisma/index.d.ts
+++ b/backend/src/generated/prisma/index.d.ts
@@ -18,6 +18,11 @@ export type PrismaPromise<T> = $Public.PrismaPromise<T>
  * 
  */
 export type usuario = $Result.DefaultSelection<Prisma.$usuarioPayload>
+/**
+ * Model Carrera
+ * 
+ */
+export type Carrera = $Result.DefaultSelection<Prisma.$CarreraPayload>
 
 /**
  * Enums
@@ -170,6 +175,16 @@ export class PrismaClient<
     * ```
     */
   get usuario(): Prisma.usuarioDelegate<ExtArgs, ClientOptions>;
+
+  /**
+   * `prisma.carrera`: Exposes CRUD operations for the **Carrera** model.
+    * Example usage:
+    * ```ts
+    * // Fetch zero or more Carreras
+    * const carreras = await prisma.carrera.findMany()
+    * ```
+    */
+  get carrera(): Prisma.CarreraDelegate<ExtArgs, ClientOptions>;
 }
 
 export namespace Prisma {
@@ -610,7 +625,8 @@ export namespace Prisma {
 
 
   export const ModelName: {
-    usuario: 'usuario'
+    usuario: 'usuario',
+    Carrera: 'Carrera'
   };
 
   export type ModelName = (typeof ModelName)[keyof typeof ModelName]
@@ -629,7 +645,7 @@ export namespace Prisma {
       omit: GlobalOmitOptions
     }
     meta: {
-      modelProps: "usuario"
+      modelProps: "usuario" | "carrera"
       txIsolationLevel: Prisma.TransactionIsolationLevel
     }
     model: {
@@ -704,6 +720,80 @@ export namespace Prisma {
           count: {
             args: Prisma.usuarioCountArgs<ExtArgs>
             result: $Utils.Optional<UsuarioCountAggregateOutputType> | number
+          }
+        }
+      }
+      Carrera: {
+        payload: Prisma.$CarreraPayload<ExtArgs>
+        fields: Prisma.CarreraFieldRefs
+        operations: {
+          findUnique: {
+            args: Prisma.CarreraFindUniqueArgs<ExtArgs>
+            result: $Utils.PayloadToResult<Prisma.$CarreraPayload> | null
+          }
+          findUniqueOrThrow: {
+            args: Prisma.CarreraFindUniqueOrThrowArgs<ExtArgs>
+            result: $Utils.PayloadToResult<Prisma.$CarreraPayload>
+          }
+          findFirst: {
+            args: Prisma.CarreraFindFirstArgs<ExtArgs>
+            result: $Utils.PayloadToResult<Prisma.$CarreraPayload> | null
+          }
+          findFirstOrThrow: {
+            args: Prisma.CarreraFindFirstOrThrowArgs<ExtArgs>
+            result: $Utils.PayloadToResult<Prisma.$CarreraPayload>
+          }
+          findMany: {
+            args: Prisma.CarreraFindManyArgs<ExtArgs>
+            result: $Utils.PayloadToResult<Prisma.$CarreraPayload>[]
+          }
+          create: {
+            args: Prisma.CarreraCreateArgs<ExtArgs>
+            result: $Utils.PayloadToResult<Prisma.$CarreraPayload>
+          }
+          createMany: {
+            args: Prisma.CarreraCreateManyArgs<ExtArgs>
+            result: BatchPayload
+          }
+          createManyAndReturn: {
+            args: Prisma.CarreraCreateManyAndReturnArgs<ExtArgs>
+            result: $Utils.PayloadToResult<Prisma.$CarreraPayload>[]
+          }
+          delete: {
+            args: Prisma.CarreraDeleteArgs<ExtArgs>
+            result: $Utils.PayloadToResult<Prisma.$CarreraPayload>
+          }
+          update: {
+            args: Prisma.CarreraUpdateArgs<ExtArgs>
+            result: $Utils.PayloadToResult<Prisma.$CarreraPayload>
+          }
+          deleteMany: {
+            args: Prisma.CarreraDeleteManyArgs<ExtArgs>
+            result: BatchPayload
+          }
+          updateMany: {
+            args: Prisma.CarreraUpdateManyArgs<ExtArgs>
+            result: BatchPayload
+          }
+          updateManyAndReturn: {
+            args: Prisma.CarreraUpdateManyAndReturnArgs<ExtArgs>
+            result: $Utils.PayloadToResult<Prisma.$CarreraPayload>[]
+          }
+          upsert: {
+            args: Prisma.CarreraUpsertArgs<ExtArgs>
+            result: $Utils.PayloadToResult<Prisma.$CarreraPayload>
+          }
+          aggregate: {
+            args: Prisma.CarreraAggregateArgs<ExtArgs>
+            result: $Utils.Optional<AggregateCarrera>
+          }
+          groupBy: {
+            args: Prisma.CarreraGroupByArgs<ExtArgs>
+            result: $Utils.Optional<CarreraGroupByOutputType>[]
+          }
+          count: {
+            args: Prisma.CarreraCountArgs<ExtArgs>
+            result: $Utils.Optional<CarreraCountAggregateOutputType> | number
           }
         }
       }
@@ -792,6 +882,7 @@ export namespace Prisma {
   }
   export type GlobalOmitConfig = {
     usuario?: usuarioOmit
+    carrera?: CarreraOmit
   }
 
   /* Types for Logging */
@@ -1934,6 +2025,988 @@ export namespace Prisma {
 
 
   /**
+   * Model Carrera
+   */
+
+  export type AggregateCarrera = {
+    _count: CarreraCountAggregateOutputType | null
+    _min: CarreraMinAggregateOutputType | null
+    _max: CarreraMaxAggregateOutputType | null
+  }
+
+  export type CarreraMinAggregateOutputType = {
+    id: string | null
+    nombre: string | null
+    estado: boolean | null
+    creadaEn: Date | null
+  }
+
+  export type CarreraMaxAggregateOutputType = {
+    id: string | null
+    nombre: string | null
+    estado: boolean | null
+    creadaEn: Date | null
+  }
+
+  export type CarreraCountAggregateOutputType = {
+    id: number
+    nombre: number
+    estado: number
+    creadaEn: number
+    _all: number
+  }
+
+
+  export type CarreraMinAggregateInputType = {
+    id?: true
+    nombre?: true
+    estado?: true
+    creadaEn?: true
+  }
+
+  export type CarreraMaxAggregateInputType = {
+    id?: true
+    nombre?: true
+    estado?: true
+    creadaEn?: true
+  }
+
+  export type CarreraCountAggregateInputType = {
+    id?: true
+    nombre?: true
+    estado?: true
+    creadaEn?: true
+    _all?: true
+  }
+
+  export type CarreraAggregateArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Filter which Carrera to aggregate.
+     */
+    where?: CarreraWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of Carreras to fetch.
+     */
+    orderBy?: CarreraOrderByWithRelationInput | CarreraOrderByWithRelationInput[]
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the start position
+     */
+    cursor?: CarreraWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take `±n` Carreras from the position of the cursor.
+     */
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first `n` Carreras.
+     */
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Count returned Carreras
+    **/
+    _count?: true | CarreraCountAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to find the minimum value
+    **/
+    _min?: CarreraMinAggregateInputType
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/aggregations Aggregation Docs}
+     * 
+     * Select which fields to find the maximum value
+    **/
+    _max?: CarreraMaxAggregateInputType
+  }
+
+  export type GetCarreraAggregateType<T extends CarreraAggregateArgs> = {
+        [P in keyof T & keyof AggregateCarrera]: P extends '_count' | 'count'
+      ? T[P] extends true
+        ? number
+        : GetScalarType<T[P], AggregateCarrera[P]>
+      : GetScalarType<T[P], AggregateCarrera[P]>
+  }
+
+
+
+
+  export type CarreraGroupByArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    where?: CarreraWhereInput
+    orderBy?: CarreraOrderByWithAggregationInput | CarreraOrderByWithAggregationInput[]
+    by: CarreraScalarFieldEnum[] | CarreraScalarFieldEnum
+    having?: CarreraScalarWhereWithAggregatesInput
+    take?: number
+    skip?: number
+    _count?: CarreraCountAggregateInputType | true
+    _min?: CarreraMinAggregateInputType
+    _max?: CarreraMaxAggregateInputType
+  }
+
+  export type CarreraGroupByOutputType = {
+    id: string
+    nombre: string
+    estado: boolean
+    creadaEn: Date
+    _count: CarreraCountAggregateOutputType | null
+    _min: CarreraMinAggregateOutputType | null
+    _max: CarreraMaxAggregateOutputType | null
+  }
+
+  type GetCarreraGroupByPayload<T extends CarreraGroupByArgs> = Prisma.PrismaPromise<
+    Array<
+      PickEnumerable<CarreraGroupByOutputType, T['by']> &
+        {
+          [P in ((keyof T) & (keyof CarreraGroupByOutputType))]: P extends '_count'
+            ? T[P] extends boolean
+              ? number
+              : GetScalarType<T[P], CarreraGroupByOutputType[P]>
+            : GetScalarType<T[P], CarreraGroupByOutputType[P]>
+        }
+      >
+    >
+
+
+  export type CarreraSelect<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = $Extensions.GetSelect<{
+    id?: boolean
+    nombre?: boolean
+    estado?: boolean
+    creadaEn?: boolean
+  }, ExtArgs["result"]["carrera"]>
+
+  export type CarreraSelectCreateManyAndReturn<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = $Extensions.GetSelect<{
+    id?: boolean
+    nombre?: boolean
+    estado?: boolean
+    creadaEn?: boolean
+  }, ExtArgs["result"]["carrera"]>
+
+  export type CarreraSelectUpdateManyAndReturn<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = $Extensions.GetSelect<{
+    id?: boolean
+    nombre?: boolean
+    estado?: boolean
+    creadaEn?: boolean
+  }, ExtArgs["result"]["carrera"]>
+
+  export type CarreraSelectScalar = {
+    id?: boolean
+    nombre?: boolean
+    estado?: boolean
+    creadaEn?: boolean
+  }
+
+  export type CarreraOmit<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = $Extensions.GetOmit<"id" | "nombre" | "estado" | "creadaEn", ExtArgs["result"]["carrera"]>
+
+  export type $CarreraPayload<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    name: "Carrera"
+    objects: {}
+    scalars: $Extensions.GetPayloadResult<{
+      id: string
+      nombre: string
+      estado: boolean
+      creadaEn: Date
+    }, ExtArgs["result"]["carrera"]>
+    composites: {}
+  }
+
+  type CarreraGetPayload<S extends boolean | null | undefined | CarreraDefaultArgs> = $Result.GetResult<Prisma.$CarreraPayload, S>
+
+  type CarreraCountArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> =
+    Omit<CarreraFindManyArgs, 'select' | 'include' | 'distinct' | 'omit'> & {
+      select?: CarreraCountAggregateInputType | true
+    }
+
+  export interface CarreraDelegate<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs, GlobalOmitOptions = {}> {
+    [K: symbol]: { types: Prisma.TypeMap<ExtArgs>['model']['Carrera'], meta: { name: 'Carrera' } }
+    /**
+     * Find zero or one Carrera that matches the filter.
+     * @param {CarreraFindUniqueArgs} args - Arguments to find a Carrera
+     * @example
+     * // Get one Carrera
+     * const carrera = await prisma.carrera.findUnique({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+     */
+    findUnique<T extends CarreraFindUniqueArgs>(args: SelectSubset<T, CarreraFindUniqueArgs<ExtArgs>>): Prisma__CarreraClient<$Result.GetResult<Prisma.$CarreraPayload<ExtArgs>, T, "findUnique", GlobalOmitOptions> | null, null, ExtArgs, GlobalOmitOptions>
+
+    /**
+     * Find one Carrera that matches the filter or throw an error with `error.code='P2025'`
+     * if no matches were found.
+     * @param {CarreraFindUniqueOrThrowArgs} args - Arguments to find a Carrera
+     * @example
+     * // Get one Carrera
+     * const carrera = await prisma.carrera.findUniqueOrThrow({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+     */
+    findUniqueOrThrow<T extends CarreraFindUniqueOrThrowArgs>(args: SelectSubset<T, CarreraFindUniqueOrThrowArgs<ExtArgs>>): Prisma__CarreraClient<$Result.GetResult<Prisma.$CarreraPayload<ExtArgs>, T, "findUniqueOrThrow", GlobalOmitOptions>, never, ExtArgs, GlobalOmitOptions>
+
+    /**
+     * Find the first Carrera that matches the filter.
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {CarreraFindFirstArgs} args - Arguments to find a Carrera
+     * @example
+     * // Get one Carrera
+     * const carrera = await prisma.carrera.findFirst({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+     */
+    findFirst<T extends CarreraFindFirstArgs>(args?: SelectSubset<T, CarreraFindFirstArgs<ExtArgs>>): Prisma__CarreraClient<$Result.GetResult<Prisma.$CarreraPayload<ExtArgs>, T, "findFirst", GlobalOmitOptions> | null, null, ExtArgs, GlobalOmitOptions>
+
+    /**
+     * Find the first Carrera that matches the filter or
+     * throw `PrismaKnownClientError` with `P2025` code if no matches were found.
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {CarreraFindFirstOrThrowArgs} args - Arguments to find a Carrera
+     * @example
+     * // Get one Carrera
+     * const carrera = await prisma.carrera.findFirstOrThrow({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+     */
+    findFirstOrThrow<T extends CarreraFindFirstOrThrowArgs>(args?: SelectSubset<T, CarreraFindFirstOrThrowArgs<ExtArgs>>): Prisma__CarreraClient<$Result.GetResult<Prisma.$CarreraPayload<ExtArgs>, T, "findFirstOrThrow", GlobalOmitOptions>, never, ExtArgs, GlobalOmitOptions>
+
+    /**
+     * Find zero or more Carreras that matches the filter.
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {CarreraFindManyArgs} args - Arguments to filter and select certain fields only.
+     * @example
+     * // Get all Carreras
+     * const carreras = await prisma.carrera.findMany()
+     * 
+     * // Get first 10 Carreras
+     * const carreras = await prisma.carrera.findMany({ take: 10 })
+     * 
+     * // Only select the `id`
+     * const carreraWithIdOnly = await prisma.carrera.findMany({ select: { id: true } })
+     * 
+     */
+    findMany<T extends CarreraFindManyArgs>(args?: SelectSubset<T, CarreraFindManyArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$CarreraPayload<ExtArgs>, T, "findMany", GlobalOmitOptions>>
+
+    /**
+     * Create a Carrera.
+     * @param {CarreraCreateArgs} args - Arguments to create a Carrera.
+     * @example
+     * // Create one Carrera
+     * const Carrera = await prisma.carrera.create({
+     *   data: {
+     *     // ... data to create a Carrera
+     *   }
+     * })
+     * 
+     */
+    create<T extends CarreraCreateArgs>(args: SelectSubset<T, CarreraCreateArgs<ExtArgs>>): Prisma__CarreraClient<$Result.GetResult<Prisma.$CarreraPayload<ExtArgs>, T, "create", GlobalOmitOptions>, never, ExtArgs, GlobalOmitOptions>
+
+    /**
+     * Create many Carreras.
+     * @param {CarreraCreateManyArgs} args - Arguments to create many Carreras.
+     * @example
+     * // Create many Carreras
+     * const carrera = await prisma.carrera.createMany({
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     *     
+     */
+    createMany<T extends CarreraCreateManyArgs>(args?: SelectSubset<T, CarreraCreateManyArgs<ExtArgs>>): Prisma.PrismaPromise<BatchPayload>
+
+    /**
+     * Create many Carreras and returns the data saved in the database.
+     * @param {CarreraCreateManyAndReturnArgs} args - Arguments to create many Carreras.
+     * @example
+     * // Create many Carreras
+     * const carrera = await prisma.carrera.createManyAndReturn({
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     * 
+     * // Create many Carreras and only return the `id`
+     * const carreraWithIdOnly = await prisma.carrera.createManyAndReturn({
+     *   select: { id: true },
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * 
+     */
+    createManyAndReturn<T extends CarreraCreateManyAndReturnArgs>(args?: SelectSubset<T, CarreraCreateManyAndReturnArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$CarreraPayload<ExtArgs>, T, "createManyAndReturn", GlobalOmitOptions>>
+
+    /**
+     * Delete a Carrera.
+     * @param {CarreraDeleteArgs} args - Arguments to delete one Carrera.
+     * @example
+     * // Delete one Carrera
+     * const Carrera = await prisma.carrera.delete({
+     *   where: {
+     *     // ... filter to delete one Carrera
+     *   }
+     * })
+     * 
+     */
+    delete<T extends CarreraDeleteArgs>(args: SelectSubset<T, CarreraDeleteArgs<ExtArgs>>): Prisma__CarreraClient<$Result.GetResult<Prisma.$CarreraPayload<ExtArgs>, T, "delete", GlobalOmitOptions>, never, ExtArgs, GlobalOmitOptions>
+
+    /**
+     * Update one Carrera.
+     * @param {CarreraUpdateArgs} args - Arguments to update one Carrera.
+     * @example
+     * // Update one Carrera
+     * const carrera = await prisma.carrera.update({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: {
+     *     // ... provide data here
+     *   }
+     * })
+     * 
+     */
+    update<T extends CarreraUpdateArgs>(args: SelectSubset<T, CarreraUpdateArgs<ExtArgs>>): Prisma__CarreraClient<$Result.GetResult<Prisma.$CarreraPayload<ExtArgs>, T, "update", GlobalOmitOptions>, never, ExtArgs, GlobalOmitOptions>
+
+    /**
+     * Delete zero or more Carreras.
+     * @param {CarreraDeleteManyArgs} args - Arguments to filter Carreras to delete.
+     * @example
+     * // Delete a few Carreras
+     * const { count } = await prisma.carrera.deleteMany({
+     *   where: {
+     *     // ... provide filter here
+     *   }
+     * })
+     * 
+     */
+    deleteMany<T extends CarreraDeleteManyArgs>(args?: SelectSubset<T, CarreraDeleteManyArgs<ExtArgs>>): Prisma.PrismaPromise<BatchPayload>
+
+    /**
+     * Update zero or more Carreras.
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {CarreraUpdateManyArgs} args - Arguments to update one or more rows.
+     * @example
+     * // Update many Carreras
+     * const carrera = await prisma.carrera.updateMany({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: {
+     *     // ... provide data here
+     *   }
+     * })
+     * 
+     */
+    updateMany<T extends CarreraUpdateManyArgs>(args: SelectSubset<T, CarreraUpdateManyArgs<ExtArgs>>): Prisma.PrismaPromise<BatchPayload>
+
+    /**
+     * Update zero or more Carreras and returns the data updated in the database.
+     * @param {CarreraUpdateManyAndReturnArgs} args - Arguments to update many Carreras.
+     * @example
+     * // Update many Carreras
+     * const carrera = await prisma.carrera.updateManyAndReturn({
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     * 
+     * // Update zero or more Carreras and only return the `id`
+     * const carreraWithIdOnly = await prisma.carrera.updateManyAndReturn({
+     *   select: { id: true },
+     *   where: {
+     *     // ... provide filter here
+     *   },
+     *   data: [
+     *     // ... provide data here
+     *   ]
+     * })
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * 
+     */
+    updateManyAndReturn<T extends CarreraUpdateManyAndReturnArgs>(args: SelectSubset<T, CarreraUpdateManyAndReturnArgs<ExtArgs>>): Prisma.PrismaPromise<$Result.GetResult<Prisma.$CarreraPayload<ExtArgs>, T, "updateManyAndReturn", GlobalOmitOptions>>
+
+    /**
+     * Create or update one Carrera.
+     * @param {CarreraUpsertArgs} args - Arguments to update or create a Carrera.
+     * @example
+     * // Update or create a Carrera
+     * const carrera = await prisma.carrera.upsert({
+     *   create: {
+     *     // ... data to create a Carrera
+     *   },
+     *   update: {
+     *     // ... in case it already exists, update
+     *   },
+     *   where: {
+     *     // ... the filter for the Carrera we want to update
+     *   }
+     * })
+     */
+    upsert<T extends CarreraUpsertArgs>(args: SelectSubset<T, CarreraUpsertArgs<ExtArgs>>): Prisma__CarreraClient<$Result.GetResult<Prisma.$CarreraPayload<ExtArgs>, T, "upsert", GlobalOmitOptions>, never, ExtArgs, GlobalOmitOptions>
+
+
+    /**
+     * Count the number of Carreras.
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {CarreraCountArgs} args - Arguments to filter Carreras to count.
+     * @example
+     * // Count the number of Carreras
+     * const count = await prisma.carrera.count({
+     *   where: {
+     *     // ... the filter for the Carreras we want to count
+     *   }
+     * })
+    **/
+    count<T extends CarreraCountArgs>(
+      args?: Subset<T, CarreraCountArgs>,
+    ): Prisma.PrismaPromise<
+      T extends $Utils.Record<'select', any>
+        ? T['select'] extends true
+          ? number
+          : GetScalarType<T['select'], CarreraCountAggregateOutputType>
+        : number
+    >
+
+    /**
+     * Allows you to perform aggregations operations on a Carrera.
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {CarreraAggregateArgs} args - Select which aggregations you would like to apply and on what fields.
+     * @example
+     * // Ordered by age ascending
+     * // Where email contains prisma.io
+     * // Limited to the 10 users
+     * const aggregations = await prisma.user.aggregate({
+     *   _avg: {
+     *     age: true,
+     *   },
+     *   where: {
+     *     email: {
+     *       contains: "prisma.io",
+     *     },
+     *   },
+     *   orderBy: {
+     *     age: "asc",
+     *   },
+     *   take: 10,
+     * })
+    **/
+    aggregate<T extends CarreraAggregateArgs>(args: Subset<T, CarreraAggregateArgs>): Prisma.PrismaPromise<GetCarreraAggregateType<T>>
+
+    /**
+     * Group by Carrera.
+     * Note, that providing `undefined` is treated as the value not being there.
+     * Read more here: https://pris.ly/d/null-undefined
+     * @param {CarreraGroupByArgs} args - Group by arguments.
+     * @example
+     * // Group by city, order by createdAt, get count
+     * const result = await prisma.user.groupBy({
+     *   by: ['city', 'createdAt'],
+     *   orderBy: {
+     *     createdAt: true
+     *   },
+     *   _count: {
+     *     _all: true
+     *   },
+     * })
+     * 
+    **/
+    groupBy<
+      T extends CarreraGroupByArgs,
+      HasSelectOrTake extends Or<
+        Extends<'skip', Keys<T>>,
+        Extends<'take', Keys<T>>
+      >,
+      OrderByArg extends True extends HasSelectOrTake
+        ? { orderBy: CarreraGroupByArgs['orderBy'] }
+        : { orderBy?: CarreraGroupByArgs['orderBy'] },
+      OrderFields extends ExcludeUnderscoreKeys<Keys<MaybeTupleToUnion<T['orderBy']>>>,
+      ByFields extends MaybeTupleToUnion<T['by']>,
+      ByValid extends Has<ByFields, OrderFields>,
+      HavingFields extends GetHavingFields<T['having']>,
+      HavingValid extends Has<ByFields, HavingFields>,
+      ByEmpty extends T['by'] extends never[] ? True : False,
+      InputErrors extends ByEmpty extends True
+      ? `Error: "by" must not be empty.`
+      : HavingValid extends False
+      ? {
+          [P in HavingFields]: P extends ByFields
+            ? never
+            : P extends string
+            ? `Error: Field "${P}" used in "having" needs to be provided in "by".`
+            : [
+                Error,
+                'Field ',
+                P,
+                ` in "having" needs to be provided in "by"`,
+              ]
+        }[HavingFields]
+      : 'take' extends Keys<T>
+      ? 'orderBy' extends Keys<T>
+        ? ByValid extends True
+          ? {}
+          : {
+              [P in OrderFields]: P extends ByFields
+                ? never
+                : `Error: Field "${P}" in "orderBy" needs to be provided in "by"`
+            }[OrderFields]
+        : 'Error: If you provide "take", you also need to provide "orderBy"'
+      : 'skip' extends Keys<T>
+      ? 'orderBy' extends Keys<T>
+        ? ByValid extends True
+          ? {}
+          : {
+              [P in OrderFields]: P extends ByFields
+                ? never
+                : `Error: Field "${P}" in "orderBy" needs to be provided in "by"`
+            }[OrderFields]
+        : 'Error: If you provide "skip", you also need to provide "orderBy"'
+      : ByValid extends True
+      ? {}
+      : {
+          [P in OrderFields]: P extends ByFields
+            ? never
+            : `Error: Field "${P}" in "orderBy" needs to be provided in "by"`
+        }[OrderFields]
+    >(args: SubsetIntersection<T, CarreraGroupByArgs, OrderByArg> & InputErrors): {} extends InputErrors ? GetCarreraGroupByPayload<T> : Prisma.PrismaPromise<InputErrors>
+  /**
+   * Fields of the Carrera model
+   */
+  readonly fields: CarreraFieldRefs;
+  }
+
+  /**
+   * The delegate class that acts as a "Promise-like" for Carrera.
+   * Why is this prefixed with `Prisma__`?
+   * Because we want to prevent naming conflicts as mentioned in
+   * https://github.com/prisma/prisma-client-js/issues/707
+   */
+  export interface Prisma__CarreraClient<T, Null = never, ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs, GlobalOmitOptions = {}> extends Prisma.PrismaPromise<T> {
+    readonly [Symbol.toStringTag]: "PrismaPromise"
+    /**
+     * Attaches callbacks for the resolution and/or rejection of the Promise.
+     * @param onfulfilled The callback to execute when the Promise is resolved.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of which ever callback is executed.
+     */
+    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): $Utils.JsPromise<TResult1 | TResult2>
+    /**
+     * Attaches a callback for only the rejection of the Promise.
+     * @param onrejected The callback to execute when the Promise is rejected.
+     * @returns A Promise for the completion of the callback.
+     */
+    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): $Utils.JsPromise<T | TResult>
+    /**
+     * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The
+     * resolved value cannot be modified from the callback.
+     * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).
+     * @returns A Promise for the completion of the callback.
+     */
+    finally(onfinally?: (() => void) | undefined | null): $Utils.JsPromise<T>
+  }
+
+
+
+
+  /**
+   * Fields of the Carrera model
+   */
+  interface CarreraFieldRefs {
+    readonly id: FieldRef<"Carrera", 'String'>
+    readonly nombre: FieldRef<"Carrera", 'String'>
+    readonly estado: FieldRef<"Carrera", 'Boolean'>
+    readonly creadaEn: FieldRef<"Carrera", 'DateTime'>
+  }
+    
+
+  // Custom InputTypes
+  /**
+   * Carrera findUnique
+   */
+  export type CarreraFindUniqueArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the Carrera
+     */
+    select?: CarreraSelect<ExtArgs> | null
+    /**
+     * Omit specific fields from the Carrera
+     */
+    omit?: CarreraOmit<ExtArgs> | null
+    /**
+     * Filter, which Carrera to fetch.
+     */
+    where: CarreraWhereUniqueInput
+  }
+
+  /**
+   * Carrera findUniqueOrThrow
+   */
+  export type CarreraFindUniqueOrThrowArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the Carrera
+     */
+    select?: CarreraSelect<ExtArgs> | null
+    /**
+     * Omit specific fields from the Carrera
+     */
+    omit?: CarreraOmit<ExtArgs> | null
+    /**
+     * Filter, which Carrera to fetch.
+     */
+    where: CarreraWhereUniqueInput
+  }
+
+  /**
+   * Carrera findFirst
+   */
+  export type CarreraFindFirstArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the Carrera
+     */
+    select?: CarreraSelect<ExtArgs> | null
+    /**
+     * Omit specific fields from the Carrera
+     */
+    omit?: CarreraOmit<ExtArgs> | null
+    /**
+     * Filter, which Carrera to fetch.
+     */
+    where?: CarreraWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of Carreras to fetch.
+     */
+    orderBy?: CarreraOrderByWithRelationInput | CarreraOrderByWithRelationInput[]
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for searching for Carreras.
+     */
+    cursor?: CarreraWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take `±n` Carreras from the position of the cursor.
+     */
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first `n` Carreras.
+     */
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
+     * 
+     * Filter by unique combinations of Carreras.
+     */
+    distinct?: CarreraScalarFieldEnum | CarreraScalarFieldEnum[]
+  }
+
+  /**
+   * Carrera findFirstOrThrow
+   */
+  export type CarreraFindFirstOrThrowArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the Carrera
+     */
+    select?: CarreraSelect<ExtArgs> | null
+    /**
+     * Omit specific fields from the Carrera
+     */
+    omit?: CarreraOmit<ExtArgs> | null
+    /**
+     * Filter, which Carrera to fetch.
+     */
+    where?: CarreraWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of Carreras to fetch.
+     */
+    orderBy?: CarreraOrderByWithRelationInput | CarreraOrderByWithRelationInput[]
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for searching for Carreras.
+     */
+    cursor?: CarreraWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take `±n` Carreras from the position of the cursor.
+     */
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first `n` Carreras.
+     */
+    skip?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/distinct Distinct Docs}
+     * 
+     * Filter by unique combinations of Carreras.
+     */
+    distinct?: CarreraScalarFieldEnum | CarreraScalarFieldEnum[]
+  }
+
+  /**
+   * Carrera findMany
+   */
+  export type CarreraFindManyArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the Carrera
+     */
+    select?: CarreraSelect<ExtArgs> | null
+    /**
+     * Omit specific fields from the Carrera
+     */
+    omit?: CarreraOmit<ExtArgs> | null
+    /**
+     * Filter, which Carreras to fetch.
+     */
+    where?: CarreraWhereInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/sorting Sorting Docs}
+     * 
+     * Determine the order of Carreras to fetch.
+     */
+    orderBy?: CarreraOrderByWithRelationInput | CarreraOrderByWithRelationInput[]
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination Cursor Docs}
+     * 
+     * Sets the position for listing Carreras.
+     */
+    cursor?: CarreraWhereUniqueInput
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Take `±n` Carreras from the position of the cursor.
+     */
+    take?: number
+    /**
+     * {@link https://www.prisma.io/docs/concepts/components/prisma-client/pagination Pagination Docs}
+     * 
+     * Skip the first `n` Carreras.
+     */
+    skip?: number
+    distinct?: CarreraScalarFieldEnum | CarreraScalarFieldEnum[]
+  }
+
+  /**
+   * Carrera create
+   */
+  export type CarreraCreateArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the Carrera
+     */
+    select?: CarreraSelect<ExtArgs> | null
+    /**
+     * Omit specific fields from the Carrera
+     */
+    omit?: CarreraOmit<ExtArgs> | null
+    /**
+     * The data needed to create a Carrera.
+     */
+    data: XOR<CarreraCreateInput, CarreraUncheckedCreateInput>
+  }
+
+  /**
+   * Carrera createMany
+   */
+  export type CarreraCreateManyArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * The data used to create many Carreras.
+     */
+    data: CarreraCreateManyInput | CarreraCreateManyInput[]
+    skipDuplicates?: boolean
+  }
+
+  /**
+   * Carrera createManyAndReturn
+   */
+  export type CarreraCreateManyAndReturnArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the Carrera
+     */
+    select?: CarreraSelectCreateManyAndReturn<ExtArgs> | null
+    /**
+     * Omit specific fields from the Carrera
+     */
+    omit?: CarreraOmit<ExtArgs> | null
+    /**
+     * The data used to create many Carreras.
+     */
+    data: CarreraCreateManyInput | CarreraCreateManyInput[]
+    skipDuplicates?: boolean
+  }
+
+  /**
+   * Carrera update
+   */
+  export type CarreraUpdateArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the Carrera
+     */
+    select?: CarreraSelect<ExtArgs> | null
+    /**
+     * Omit specific fields from the Carrera
+     */
+    omit?: CarreraOmit<ExtArgs> | null
+    /**
+     * The data needed to update a Carrera.
+     */
+    data: XOR<CarreraUpdateInput, CarreraUncheckedUpdateInput>
+    /**
+     * Choose, which Carrera to update.
+     */
+    where: CarreraWhereUniqueInput
+  }
+
+  /**
+   * Carrera updateMany
+   */
+  export type CarreraUpdateManyArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * The data used to update Carreras.
+     */
+    data: XOR<CarreraUpdateManyMutationInput, CarreraUncheckedUpdateManyInput>
+    /**
+     * Filter which Carreras to update
+     */
+    where?: CarreraWhereInput
+    /**
+     * Limit how many Carreras to update.
+     */
+    limit?: number
+  }
+
+  /**
+   * Carrera updateManyAndReturn
+   */
+  export type CarreraUpdateManyAndReturnArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the Carrera
+     */
+    select?: CarreraSelectUpdateManyAndReturn<ExtArgs> | null
+    /**
+     * Omit specific fields from the Carrera
+     */
+    omit?: CarreraOmit<ExtArgs> | null
+    /**
+     * The data used to update Carreras.
+     */
+    data: XOR<CarreraUpdateManyMutationInput, CarreraUncheckedUpdateManyInput>
+    /**
+     * Filter which Carreras to update
+     */
+    where?: CarreraWhereInput
+    /**
+     * Limit how many Carreras to update.
+     */
+    limit?: number
+  }
+
+  /**
+   * Carrera upsert
+   */
+  export type CarreraUpsertArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the Carrera
+     */
+    select?: CarreraSelect<ExtArgs> | null
+    /**
+     * Omit specific fields from the Carrera
+     */
+    omit?: CarreraOmit<ExtArgs> | null
+    /**
+     * The filter to search for the Carrera to update in case it exists.
+     */
+    where: CarreraWhereUniqueInput
+    /**
+     * In case the Carrera found by the `where` argument doesn't exist, create a new Carrera with this data.
+     */
+    create: XOR<CarreraCreateInput, CarreraUncheckedCreateInput>
+    /**
+     * In case the Carrera was found with the provided `where` argument, update it with this data.
+     */
+    update: XOR<CarreraUpdateInput, CarreraUncheckedUpdateInput>
+  }
+
+  /**
+   * Carrera delete
+   */
+  export type CarreraDeleteArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the Carrera
+     */
+    select?: CarreraSelect<ExtArgs> | null
+    /**
+     * Omit specific fields from the Carrera
+     */
+    omit?: CarreraOmit<ExtArgs> | null
+    /**
+     * Filter which Carrera to delete.
+     */
+    where: CarreraWhereUniqueInput
+  }
+
+  /**
+   * Carrera deleteMany
+   */
+  export type CarreraDeleteManyArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Filter which Carreras to delete
+     */
+    where?: CarreraWhereInput
+    /**
+     * Limit how many Carreras to delete.
+     */
+    limit?: number
+  }
+
+  /**
+   * Carrera without action
+   */
+  export type CarreraDefaultArgs<ExtArgs extends $Extensions.InternalArgs = $Extensions.DefaultArgs> = {
+    /**
+     * Select specific fields to fetch from the Carrera
+     */
+    select?: CarreraSelect<ExtArgs> | null
+    /**
+     * Omit specific fields from the Carrera
+     */
+    omit?: CarreraOmit<ExtArgs> | null
+  }
+
+
+  /**
    * Enums
    */
 
@@ -1960,6 +3033,16 @@ export namespace Prisma {
   };
 
   export type UsuarioScalarFieldEnum = (typeof UsuarioScalarFieldEnum)[keyof typeof UsuarioScalarFieldEnum]
+
+
+  export const CarreraScalarFieldEnum: {
+    id: 'id',
+    nombre: 'nombre',
+    estado: 'estado',
+    creadaEn: 'creadaEn'
+  };
+
+  export type CarreraScalarFieldEnum = (typeof CarreraScalarFieldEnum)[keyof typeof CarreraScalarFieldEnum]
 
 
   export const SortOrder: {
@@ -2022,6 +3105,13 @@ export namespace Prisma {
    * Reference to a field of type 'DateTime[]'
    */
   export type ListDateTimeFieldRefInput<$PrismaModel> = FieldRefInputType<$PrismaModel, 'DateTime[]'>
+    
+
+
+  /**
+   * Reference to a field of type 'Boolean'
+   */
+  export type BooleanFieldRefInput<$PrismaModel> = FieldRefInputType<$PrismaModel, 'Boolean'>
     
 
 
@@ -2114,6 +3204,53 @@ export namespace Prisma {
     fec_cre_usu?: DateTimeWithAggregatesFilter<"usuario"> | Date | string
   }
 
+  export type CarreraWhereInput = {
+    AND?: CarreraWhereInput | CarreraWhereInput[]
+    OR?: CarreraWhereInput[]
+    NOT?: CarreraWhereInput | CarreraWhereInput[]
+    id?: StringFilter<"Carrera"> | string
+    nombre?: StringFilter<"Carrera"> | string
+    estado?: BoolFilter<"Carrera"> | boolean
+    creadaEn?: DateTimeFilter<"Carrera"> | Date | string
+  }
+
+  export type CarreraOrderByWithRelationInput = {
+    id?: SortOrder
+    nombre?: SortOrder
+    estado?: SortOrder
+    creadaEn?: SortOrder
+  }
+
+  export type CarreraWhereUniqueInput = Prisma.AtLeast<{
+    id?: string
+    nombre?: string
+    AND?: CarreraWhereInput | CarreraWhereInput[]
+    OR?: CarreraWhereInput[]
+    NOT?: CarreraWhereInput | CarreraWhereInput[]
+    estado?: BoolFilter<"Carrera"> | boolean
+    creadaEn?: DateTimeFilter<"Carrera"> | Date | string
+  }, "id" | "nombre">
+
+  export type CarreraOrderByWithAggregationInput = {
+    id?: SortOrder
+    nombre?: SortOrder
+    estado?: SortOrder
+    creadaEn?: SortOrder
+    _count?: CarreraCountOrderByAggregateInput
+    _max?: CarreraMaxOrderByAggregateInput
+    _min?: CarreraMinOrderByAggregateInput
+  }
+
+  export type CarreraScalarWhereWithAggregatesInput = {
+    AND?: CarreraScalarWhereWithAggregatesInput | CarreraScalarWhereWithAggregatesInput[]
+    OR?: CarreraScalarWhereWithAggregatesInput[]
+    NOT?: CarreraScalarWhereWithAggregatesInput | CarreraScalarWhereWithAggregatesInput[]
+    id?: StringWithAggregatesFilter<"Carrera"> | string
+    nombre?: StringWithAggregatesFilter<"Carrera"> | string
+    estado?: BoolWithAggregatesFilter<"Carrera"> | boolean
+    creadaEn?: DateTimeWithAggregatesFilter<"Carrera"> | Date | string
+  }
+
   export type usuarioCreateInput = {
     id_usu?: string
     ced_usu: string
@@ -2196,6 +3333,55 @@ export namespace Prisma {
     cel_usu?: StringFieldUpdateOperationsInput | string
     rol_usu?: Enumrol_usuarioFieldUpdateOperationsInput | $Enums.rol_usuario
     fec_cre_usu?: DateTimeFieldUpdateOperationsInput | Date | string
+  }
+
+  export type CarreraCreateInput = {
+    id?: string
+    nombre: string
+    estado?: boolean
+    creadaEn?: Date | string
+  }
+
+  export type CarreraUncheckedCreateInput = {
+    id?: string
+    nombre: string
+    estado?: boolean
+    creadaEn?: Date | string
+  }
+
+  export type CarreraUpdateInput = {
+    id?: StringFieldUpdateOperationsInput | string
+    nombre?: StringFieldUpdateOperationsInput | string
+    estado?: BoolFieldUpdateOperationsInput | boolean
+    creadaEn?: DateTimeFieldUpdateOperationsInput | Date | string
+  }
+
+  export type CarreraUncheckedUpdateInput = {
+    id?: StringFieldUpdateOperationsInput | string
+    nombre?: StringFieldUpdateOperationsInput | string
+    estado?: BoolFieldUpdateOperationsInput | boolean
+    creadaEn?: DateTimeFieldUpdateOperationsInput | Date | string
+  }
+
+  export type CarreraCreateManyInput = {
+    id?: string
+    nombre: string
+    estado?: boolean
+    creadaEn?: Date | string
+  }
+
+  export type CarreraUpdateManyMutationInput = {
+    id?: StringFieldUpdateOperationsInput | string
+    nombre?: StringFieldUpdateOperationsInput | string
+    estado?: BoolFieldUpdateOperationsInput | boolean
+    creadaEn?: DateTimeFieldUpdateOperationsInput | Date | string
+  }
+
+  export type CarreraUncheckedUpdateManyInput = {
+    id?: StringFieldUpdateOperationsInput | string
+    nombre?: StringFieldUpdateOperationsInput | string
+    estado?: BoolFieldUpdateOperationsInput | boolean
+    creadaEn?: DateTimeFieldUpdateOperationsInput | Date | string
   }
 
   export type StringFilter<$PrismaModel = never> = {
@@ -2309,6 +3495,40 @@ export namespace Prisma {
     _max?: NestedDateTimeFilter<$PrismaModel>
   }
 
+  export type BoolFilter<$PrismaModel = never> = {
+    equals?: boolean | BooleanFieldRefInput<$PrismaModel>
+    not?: NestedBoolFilter<$PrismaModel> | boolean
+  }
+
+  export type CarreraCountOrderByAggregateInput = {
+    id?: SortOrder
+    nombre?: SortOrder
+    estado?: SortOrder
+    creadaEn?: SortOrder
+  }
+
+  export type CarreraMaxOrderByAggregateInput = {
+    id?: SortOrder
+    nombre?: SortOrder
+    estado?: SortOrder
+    creadaEn?: SortOrder
+  }
+
+  export type CarreraMinOrderByAggregateInput = {
+    id?: SortOrder
+    nombre?: SortOrder
+    estado?: SortOrder
+    creadaEn?: SortOrder
+  }
+
+  export type BoolWithAggregatesFilter<$PrismaModel = never> = {
+    equals?: boolean | BooleanFieldRefInput<$PrismaModel>
+    not?: NestedBoolWithAggregatesFilter<$PrismaModel> | boolean
+    _count?: NestedIntFilter<$PrismaModel>
+    _min?: NestedBoolFilter<$PrismaModel>
+    _max?: NestedBoolFilter<$PrismaModel>
+  }
+
   export type StringFieldUpdateOperationsInput = {
     set?: string
   }
@@ -2319,6 +3539,10 @@ export namespace Prisma {
 
   export type DateTimeFieldUpdateOperationsInput = {
     set?: Date | string
+  }
+
+  export type BoolFieldUpdateOperationsInput = {
+    set?: boolean
   }
 
   export type NestedStringFilter<$PrismaModel = never> = {
@@ -2403,6 +3627,19 @@ export namespace Prisma {
     _count?: NestedIntFilter<$PrismaModel>
     _min?: NestedDateTimeFilter<$PrismaModel>
     _max?: NestedDateTimeFilter<$PrismaModel>
+  }
+
+  export type NestedBoolFilter<$PrismaModel = never> = {
+    equals?: boolean | BooleanFieldRefInput<$PrismaModel>
+    not?: NestedBoolFilter<$PrismaModel> | boolean
+  }
+
+  export type NestedBoolWithAggregatesFilter<$PrismaModel = never> = {
+    equals?: boolean | BooleanFieldRefInput<$PrismaModel>
+    not?: NestedBoolWithAggregatesFilter<$PrismaModel> | boolean
+    _count?: NestedIntFilter<$PrismaModel>
+    _min?: NestedBoolFilter<$PrismaModel>
+    _max?: NestedBoolFilter<$PrismaModel>
   }
 
 

--- a/backend/src/generated/prisma/index.js
+++ b/backend/src/generated/prisma/index.js
@@ -105,6 +105,13 @@ exports.Prisma.UsuarioScalarFieldEnum = {
   fec_cre_usu: 'fec_cre_usu'
 };
 
+exports.Prisma.CarreraScalarFieldEnum = {
+  id: 'id',
+  nombre: 'nombre',
+  estado: 'estado',
+  creadaEn: 'creadaEn'
+};
+
 exports.Prisma.SortOrder = {
   asc: 'asc',
   desc: 'desc'
@@ -120,7 +127,8 @@ exports.rol_usuario = exports.$Enums.rol_usuario = {
 };
 
 exports.Prisma.ModelName = {
-  usuario: 'usuario'
+  usuario: 'usuario',
+  Carrera: 'Carrera'
 };
 /**
  * Create the Client
@@ -133,7 +141,7 @@ const config = {
       "value": "prisma-client-js"
     },
     "output": {
-      "value": "C:\\Users\\gabri\\OneDrive\\Desktop\\AcademicEvents\\backend\\src\\generated\\prisma",
+      "value": "C:\\Users\\User\\Desktop\\academicEvents\\AcademicEvents\\backend\\src\\generated\\prisma",
       "fromEnvVar": null
     },
     "config": {
@@ -147,7 +155,7 @@ const config = {
       }
     ],
     "previewFeatures": [],
-    "sourceFilePath": "C:\\Users\\gabri\\OneDrive\\Desktop\\AcademicEvents\\backend\\prisma\\schema.prisma",
+    "sourceFilePath": "C:\\Users\\User\\Desktop\\academicEvents\\AcademicEvents\\backend\\prisma\\schema.prisma",
     "isCustomOutput": true
   },
   "relativeEnvPaths": {
@@ -161,17 +169,16 @@ const config = {
     "db"
   ],
   "activeProvider": "postgresql",
-  "postinstall": false,
   "inlineDatasources": {
     "db": {
       "url": {
         "fromEnvVar": "DATABASE_URL",
-        "value": null
+        "value": "postgresql://postgres:12345@localhost:5432/academicevents"
       }
     }
   },
-  "inlineSchema": "generator client {\n  provider = \"prisma-client-js\"\n  output   = \"../src/generated/prisma\"\n}\n\ndatasource db {\n  provider = \"postgresql\"\n  url      = env(\"DATABASE_URL\")\n}\n\nmodel usuario {\n  id_usu      String      @id @default(uuid())\n  ced_usu     String      @unique\n  nom_usu     String\n  ape_usu     String\n  cor_usu     String      @unique\n  con_usu     String\n  cel_usu     String      @db.Char(10) //Acepta solo 10 caracteres\n  rol_usu     rol_usuario\n  fec_cre_usu DateTime    @default(now())\n}\n\nenum rol_usuario {\n  ADMIN\n  ESTUDIANTE\n}\n",
-  "inlineSchemaHash": "81e9fd5271bbbeb9fc318243fe2494d50983d7beb52884a9b53ae3576347caf0",
+  "inlineSchema": "generator client {\n  provider = \"prisma-client-js\"\n  output   = \"../src/generated/prisma\"\n}\n\ndatasource db {\n  provider = \"postgresql\"\n  url      = env(\"DATABASE_URL\")\n}\n\nmodel usuario {\n  id_usu      String      @id @default(uuid())\n  ced_usu     String      @unique\n  nom_usu     String\n  ape_usu     String\n  cor_usu     String      @unique\n  con_usu     String\n  cel_usu     String      @db.Char(10) //Acepta solo 10 caracteres\n  rol_usu     rol_usuario\n  fec_cre_usu DateTime    @default(now())\n}\n\nmodel Carrera {\n  id       String   @id @default(uuid())\n  nombre   String   @unique\n  estado   Boolean  @default(true)\n  creadaEn DateTime @default(now())\n}\n\nenum rol_usuario {\n  ADMIN\n  ESTUDIANTE\n}\n",
+  "inlineSchemaHash": "b180025db88e7593dc7fc08d49be91b171315f5025a68f831e26d6c76788b1f9",
   "copyEngine": true
 }
 
@@ -192,7 +199,7 @@ if (!fs.existsSync(path.join(__dirname, 'schema.prisma'))) {
   config.isBundled = true
 }
 
-config.runtimeDataModel = JSON.parse("{\"models\":{\"usuario\":{\"dbName\":null,\"schema\":null,\"fields\":[{\"name\":\"id_usu\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":false,\"isId\":true,\"isReadOnly\":false,\"hasDefaultValue\":true,\"type\":\"String\",\"nativeType\":null,\"default\":{\"name\":\"uuid\",\"args\":[4]},\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"ced_usu\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":true,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":false,\"type\":\"String\",\"nativeType\":null,\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"nom_usu\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":false,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":false,\"type\":\"String\",\"nativeType\":null,\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"ape_usu\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":false,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":false,\"type\":\"String\",\"nativeType\":null,\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"cor_usu\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":true,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":false,\"type\":\"String\",\"nativeType\":null,\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"con_usu\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":false,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":false,\"type\":\"String\",\"nativeType\":null,\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"cel_usu\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":false,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":false,\"type\":\"String\",\"nativeType\":[\"Char\",[\"10\"]],\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"rol_usu\",\"kind\":\"enum\",\"isList\":false,\"isRequired\":true,\"isUnique\":false,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":false,\"type\":\"rol_usuario\",\"nativeType\":null,\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"fec_cre_usu\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":false,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":true,\"type\":\"DateTime\",\"nativeType\":null,\"default\":{\"name\":\"now\",\"args\":[]},\"isGenerated\":false,\"isUpdatedAt\":false}],\"primaryKey\":null,\"uniqueFields\":[],\"uniqueIndexes\":[],\"isGenerated\":false}},\"enums\":{\"rol_usuario\":{\"values\":[{\"name\":\"ADMIN\",\"dbName\":null},{\"name\":\"ESTUDIANTE\",\"dbName\":null}],\"dbName\":null}},\"types\":{}}")
+config.runtimeDataModel = JSON.parse("{\"models\":{\"usuario\":{\"dbName\":null,\"schema\":null,\"fields\":[{\"name\":\"id_usu\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":false,\"isId\":true,\"isReadOnly\":false,\"hasDefaultValue\":true,\"type\":\"String\",\"nativeType\":null,\"default\":{\"name\":\"uuid\",\"args\":[4]},\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"ced_usu\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":true,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":false,\"type\":\"String\",\"nativeType\":null,\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"nom_usu\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":false,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":false,\"type\":\"String\",\"nativeType\":null,\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"ape_usu\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":false,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":false,\"type\":\"String\",\"nativeType\":null,\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"cor_usu\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":true,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":false,\"type\":\"String\",\"nativeType\":null,\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"con_usu\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":false,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":false,\"type\":\"String\",\"nativeType\":null,\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"cel_usu\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":false,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":false,\"type\":\"String\",\"nativeType\":[\"Char\",[\"10\"]],\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"rol_usu\",\"kind\":\"enum\",\"isList\":false,\"isRequired\":true,\"isUnique\":false,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":false,\"type\":\"rol_usuario\",\"nativeType\":null,\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"fec_cre_usu\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":false,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":true,\"type\":\"DateTime\",\"nativeType\":null,\"default\":{\"name\":\"now\",\"args\":[]},\"isGenerated\":false,\"isUpdatedAt\":false}],\"primaryKey\":null,\"uniqueFields\":[],\"uniqueIndexes\":[],\"isGenerated\":false},\"Carrera\":{\"dbName\":null,\"schema\":null,\"fields\":[{\"name\":\"id\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":false,\"isId\":true,\"isReadOnly\":false,\"hasDefaultValue\":true,\"type\":\"String\",\"nativeType\":null,\"default\":{\"name\":\"uuid\",\"args\":[4]},\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"nombre\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":true,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":false,\"type\":\"String\",\"nativeType\":null,\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"estado\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":false,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":true,\"type\":\"Boolean\",\"nativeType\":null,\"default\":true,\"isGenerated\":false,\"isUpdatedAt\":false},{\"name\":\"creadaEn\",\"kind\":\"scalar\",\"isList\":false,\"isRequired\":true,\"isUnique\":false,\"isId\":false,\"isReadOnly\":false,\"hasDefaultValue\":true,\"type\":\"DateTime\",\"nativeType\":null,\"default\":{\"name\":\"now\",\"args\":[]},\"isGenerated\":false,\"isUpdatedAt\":false}],\"primaryKey\":null,\"uniqueFields\":[],\"uniqueIndexes\":[],\"isGenerated\":false}},\"enums\":{\"rol_usuario\":{\"values\":[{\"name\":\"ADMIN\",\"dbName\":null},{\"name\":\"ESTUDIANTE\",\"dbName\":null}],\"dbName\":null}},\"types\":{}}")
 defineDmmfProperty(exports.Prisma, config.runtimeDataModel)
 config.engineWasm = undefined
 config.compilerWasm = undefined

--- a/backend/src/generated/prisma/package.json
+++ b/backend/src/generated/prisma/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "prisma-client-347f73102508f27c0729cc6c63b6c86b238bb05353fc64332686a16167d16492",
+  "name": "prisma-client-c94a5ac74addfd8ffc5dc28a7f3e882d299708a0cf1b1204d2473cd0699787f2",
   "main": "index.js",
   "types": "index.d.ts",
   "browser": "index-browser.js",

--- a/backend/src/generated/prisma/schema.prisma
+++ b/backend/src/generated/prisma/schema.prisma
@@ -20,6 +20,13 @@ model usuario {
   fec_cre_usu DateTime    @default(now())
 }
 
+model Carrera {
+  id       String   @id @default(uuid())
+  nombre   String   @unique
+  estado   Boolean  @default(true)
+  creadaEn DateTime @default(now())
+}
+
 enum rol_usuario {
   ADMIN
   ESTUDIANTE

--- a/backend/src/generated/prisma/wasm.js
+++ b/backend/src/generated/prisma/wasm.js
@@ -132,6 +132,13 @@ exports.Prisma.UsuarioScalarFieldEnum = {
   fec_cre_usu: 'fec_cre_usu'
 };
 
+exports.Prisma.CarreraScalarFieldEnum = {
+  id: 'id',
+  nombre: 'nombre',
+  estado: 'estado',
+  creadaEn: 'creadaEn'
+};
+
 exports.Prisma.SortOrder = {
   asc: 'asc',
   desc: 'desc'
@@ -147,7 +154,8 @@ exports.rol_usuario = exports.$Enums.rol_usuario = {
 };
 
 exports.Prisma.ModelName = {
-  usuario: 'usuario'
+  usuario: 'usuario',
+  Carrera: 'Carrera'
 };
 
 /**

--- a/backend/src/routes/carrera.routes.js
+++ b/backend/src/routes/carrera.routes.js
@@ -1,0 +1,16 @@
+import express from 'express';
+import {
+  obtenerCarreras,
+  crearCarrera,
+  actualizarCarrera,
+  eliminarCarrera
+} from '../controllers/carrera.controller.js';
+
+const router = express.Router();
+
+router.get('/carreras', obtenerCarreras);
+router.post('/carreras', crearCarrera);
+router.put('/carreras/:id', actualizarCarrera);
+router.delete('/carreras/:id', eliminarCarrera);
+
+export default router;


### PR DESCRIPTION
Este pull request implementa el modelo Carrera en el sistema, permitiendo su gestión desde el backend mediante operaciones CRUD. Esta funcionalidad es esencial para permitir la asignación de cursos/eventos a carreras específicas y asegurar que los usuarios institucionales puedan completar correctamente su perfil.

 Cambios realizados:
 Añadido el modelo Carrera en prisma/schema.prisma.

Ejecutado npx prisma db push para reflejar los cambios en la base de datos.

Creado controlador carrera.controller.js con operaciones CRUD (obtener, crear, actualizar, eliminar).
 Creado archivo de rutas carrera.routes.js y vinculado en app.js.

Issue relacionado
Closes #8 